### PR TITLE
feature/editor-config-standards

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,6 +10,5 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
-[*.md]
+[*.yaml.j2]
 indent_size = 4
-trim_trailing_whitespace = false


### PR DESCRIPTION
Modified the .editorconfig to fall in line with standards for yaml.j2 file structure on pikvm. Additionally removed the *.md config since it was not needed for proper indentation of the file.
