### PR TITLE
feature/validators-config

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ The following PiKVM version(s) are currently unsupported and may not work with t
 
 `hdmi.edid.custom` If set, a custom HDMI EDID value will override the PiKVM default. By default, the EDID value will be set based on the PiKVM OS version.
 
+`validate.validators.system` By setting this value to **true**, this role will validate the PiKVM required files and system packages before configuring anything. When using an official PiKVM OS provided by PiKVM, this should pass without issue, however, by setting this value to **true**, it ensures that any custom OS is able to be properly configured. By default this is set to **true**.
+
+`validate.validators.prometheus` By default PiKVM allows Prometheus scraping by exposing metrics on the `/api/export/prometheus/metrics` endpoint. By setting this value to **true**, this role will validate that the metrics endpoint is available and correctly configured. By default this is set to **true**.
+
+`validate.fail_on_validate` By setting this value to **true**, any validators that fail will stop the role from continuing execution. This is helpful to prevent unknown issues from occuring during role execution if a validator fails. By default this is set to **true**.
+
 ### Example Variable Usage
 
 ```yaml
@@ -72,6 +78,11 @@ hdmi:
       00000000000000000000000000000000
       00000000000000000000000000000000
       00000000000000000000000000000045
+validate:
+  validators:
+    system: true
+    prometheus: true
+  fail_on_validate: false
 ```
 
 ## Example Playbook

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,3 +11,8 @@ pikvm_os_update_output_logs: true
 hdmi:
   edid:
     custom: null
+validate:
+  validators:
+    system: true
+    prometheus: true
+  fail_on_validate: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,13 +1,11 @@
 ---
-- name: Check if kvmd binary exists
-  ansible.builtin.stat:
-    path: /usr/bin/kvmd
-  register: kvmd_binary
+- name: Validate System
+  ansible.builtin.import_tasks: validate/system-validate.yml
+  when: (validate.validators.system | bool)
 
-- name: Fail if kvmd binary is not found
-  ansible.builtin.fail:
-    msg: "PiKVM (kvmd) is not installed."
-  when: not kvmd_binary.stat.exists
+- name: Validate Prometheus
+  ansible.builtin.import_tasks: validate/prometheus-validate.yml
+  when: (validate.validators.prometheus | bool)
 
 - name: Check and extract PiKVM OS version
   ansible.builtin.shell:

--- a/tasks/validate/prometheus-validate.yml
+++ b/tasks/validate/prometheus-validate.yml
@@ -1,0 +1,26 @@
+---
+# TODO update validate_certs check when certificates are enabled
+# TODO update X-KVMD user and password on existing credentials
+- name: Prometheus Validate - Check if Prometheus metrics endpoint is accessible
+  ansible.builtin.uri:
+    url: "https://{{ ansible_host }}/api/export/prometheus/metrics"
+    method: GET
+    status_code: 200
+    timeout: 10
+    headers:
+      X-KVMD-User: "admin"
+      X-KVMD-Passwd: "admin"
+    validate_certs: false
+  register: prometheus_check
+  failed_when: false
+
+- name: Prometheus Validate - Display status of Prometheus metrics endpoint
+  ansible.builtin.debug:
+    msg: >-
+      {{
+        'Prometheus metrics endpoint successfully validated.' if prometheus_check.status == 200
+        else 'Prometheus metrics endpoint unsuccessfully validated.'
+      }}
+  failed_when: >
+    (prometheus_check.status != 200)
+    and (validate.fail_on_validate)

--- a/tasks/validate/system-validate.yml
+++ b/tasks/validate/system-validate.yml
@@ -1,0 +1,16 @@
+---
+- name: System Validate - Check if kvmd binary exists
+  ansible.builtin.stat:
+    path: /usr/bin/kvmd
+  register: kvmd_binary
+
+- name: System Validate - Output message based on kvmd binary presence
+  ansible.builtin.debug:
+    msg: >-
+      {{
+        'PiKVM (kvmd) system successfully validated.' if kvmd_binary.stat.exists
+        else 'PiKVM (kvmd) system unsuccessfully validated.'
+      }}
+  failed_when: >
+    (not kvmd_binary.stat.exists)
+    and (validate.fail_on_validate)


### PR DESCRIPTION
Created a validators directory to start validation of the system to ensure everything required is present and accessible. This also allows validation of the prometheus metrics endpoint. Added an option to fail on error to prevent changes when validation fails. This will be improved upon in the future.