### PR TITLE
feature/system-updates-order

### DIFF
--- a/tasks/shared/filesystem-mode.yml
+++ b/tasks/shared/filesystem-mode.yml
@@ -8,11 +8,11 @@
     current_root_fs_mode: "{{ 'rw' if 'rw' in root_mount.options else 'ro' }}"
     current_boot_fs_mode: "{{ 'rw' if 'rw' in boot_mount.options else 'ro' }}"
 
-# TODO Modify task to contain changed_when check
 - name: Filesystem Mode - Set filesystem to desired mode
   ansible.builtin.command:
     cmd: "/usr/bin/{{ fs_mode }}"
   when: current_root_fs_mode != fs_mode or current_boot_fs_mode != fs_mode
+  changed_when: true
   register: fs_change
   notify: Filesystem ro
 

--- a/tasks/system-updates.yml
+++ b/tasks/system-updates.yml
@@ -27,14 +27,14 @@
   ansible.builtin.command:
     cmd: /usr/bin/pikvm-update
   register: pikvm_update_result
-  changed_when: "'updated' in pikvm_update_result.stdout"
+  changed_when: "'Reboot required.' in pikvm_update_result.stdout"
   notify: Reboot PiKVM
-
-- name: System Updates - Flush handlers to initiate system reboot
-  ansible.builtin.meta: flush_handlers
-  when: "'Reboot required.' in pikvm_update_result.stdout"
 
 - name: System Updates - Output the result of pikvm-update
   ansible.builtin.debug:
     msg: "PiKVM update output: {{ pikvm_update_result.stdout }}"
   when: (pikvm_os_update_output_logs | bool)
+
+- name: System Updates - Flush handlers to initiate system reboot
+  ansible.builtin.meta: flush_handlers
+  when: "'Reboot required.' in pikvm_update_result.stdout"


### PR DESCRIPTION
Modified the system-updates.yml task to contain a new check for reboot after updating. Additionally, re-ordered the flush_handlers task to output logs before reboot of PiKVM.
