### PR TITLE
feature/kvmd-override-config

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,19 @@ The following PiKVM version(s) are currently unsupported and may not work with t
 
 `hdmi.edid.custom` If set, a custom HDMI EDID value will override the PiKVM default. By default, the EDID value will be set based on the PiKVM OS version.
 
+`hdmi.passthrough.enabled` This option is only available for PiKVM V4 Plus. By setting this value to **false**, the OUT2 port on the back side of the PiKVM V4 Plus will be disabled. By default this option is set to **true**. To enable this setting, `kvmd_override.enabled` must also be set to **true**.
+
 `validate.validators.system` By setting this value to **true**, this role will validate the PiKVM required files and system packages before configuring anything. When using an official PiKVM OS provided by PiKVM, this should pass without issue, however, by setting this value to **true**, it ensures that any custom OS is able to be properly configured. By default this is set to **true**.
 
 `validate.validators.prometheus` By default PiKVM allows Prometheus scraping by exposing metrics on the `/api/export/prometheus/metrics` endpoint. By setting this value to **true**, this role will validate that the metrics endpoint is available and correctly configured. By default this is set to **true**.
 
 `validate.fail_on_validate` By setting this value to **true**, any validators that fail will stop the role from continuing execution. This is helpful to prevent unknown issues from occuring during role execution if a validator fails. By default this is set to **true**.
+
+`hid.mouse.jiggler.enabled` By setting this value to **true**, the virtual mouse jiggler will be available for use within the WebUI. By default this value is set to **false**. This setting does not turn ON the mouse jiggler, instead, it allows the user to activate it manually. To enable this setting, `kvmd_override.enabled` must also be set to **true**.
+
+`hid.mouse.jiggler.on_after_reboot` By setting this value to **true**, the virtual mouse jiggler will become active after reboot. By default this value is set to **false**. This setting turns ON the mouse jiggler by default after reboot. If you wish to have manual control over the activation of this setting after reboot, do not set this value to true. `hid.mouse.jiggler.enabled` must be set to **true** for this setting to be applied. To enable this setting, `kvmd_override.enabled` must also be set to **true**.
+
+`kvmd_override.enabled` By setting this value to **true**, the current override file within /etc/kvmd/override.yaml will be overwritten to match this roles config. By default this value is set to **false**.
 
 ### Example Variable Usage
 
@@ -78,11 +86,20 @@ hdmi:
       00000000000000000000000000000000
       00000000000000000000000000000000
       00000000000000000000000000000045
+  passthrough:
+    enabled: false
 validate:
   validators:
     system: true
     prometheus: true
   fail_on_validate: false
+hid:
+  mouse:
+    jiggler:
+      enabled: true
+      on_after_reboot: true
+kvmd_override:
+  enabled: true
 ```
 
 ## Example Playbook
@@ -106,15 +123,23 @@ validate:
         name: ol3d.pikvm
 ```
 
-## HDMI EDID
+## HDMI
+
+### EDID
 
 This role can be used to modify the EDID on the Raspberry Pi. The default action for this role is to utilize the default preset EDID based on the PiKVM OS version. When modifying the EDID, a custom value must be provided as a role variable. There are a list of available EDID file presets located either on the PiKVM official documentation [here](https://docs.pikvm.org/edid/), or a more comprehensive list of EDID files can be found [here](https://github.com/linuxhw/EDID/tree/master).
+
+### Passthrough
+
+On a PiKVM V4 Plus, there is an option to use the PiKVM as a HDMI Video Passthrough. By connecting the display to the OUT2 port on the back side of the PiKVM, it allows you to gap between the target host and physical display. This prevents PiKVM from interfereing with the normal operation of the display and passes video signal through itself until you need remote access. PiKVM directs the video stream to the WebUI or VNC.
 
 ## Disclaimer
 
 This role will update system packages if available to the most recent version. This action cannot currently be disabled.
 
 This role will cause the PiKVM to reboot if required. This action cannot currently be disabled.
+
+If `kvmd_override.enabled` is set to **true**, the current /etc/kvmd/override.yaml file will be overwritten and cannot be recovered. Please ensure that you have a backup of the current override.yaml file.
 
 **Warning**: By using this role, you acknowledge that it may impact any existing installations or configurations on your PiKVM device. This role and its contributors are not responsible for any data loss, configuration changes, or other issues that may arise. Use at your own risk and ensure you have appropriate backups and safeguards in place before running this role on a production device.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,8 +11,17 @@ pikvm_os_update_output_logs: true
 hdmi:
   edid:
     custom: null
+  passthrough:
+    enabled: false
 validate:
   validators:
     system: true
     prometheus: true
   fail_on_validate: false
+hid:
+  mouse:
+    jiggler:
+      enabled: false
+      on_after_reboot: false
+kvmd_override:
+  enabled: false

--- a/tasks/kvmd-override-config.yml
+++ b/tasks/kvmd-override-config.yml
@@ -1,0 +1,36 @@
+---
+- name: KVMD Override Config - Check if /etc/kvmd/override.yaml exists
+  ansible.builtin.stat:
+    path: /etc/kvmd/override.yaml
+  register: kvmd_override_file
+
+- name: KVMD Override Config - Read current contents of /etc/kvmd/override.yaml if it exists
+  ansible.builtin.slurp:
+    path: /etc/kvmd/override.yaml
+  when: kvmd_override_file.stat.exists
+  register: current_kvmd_override_file
+
+- name: KVMD Override Config - Render the kvmd override template content in memory and compare
+  ansible.builtin.set_fact:
+    kvmd_override_contents_change_required: >
+      {{
+        not kvmd_override_file.stat.exists or
+        (kvmd_override_file.stat.exists and
+        (current_kvmd_override_file.content | b64decode) != lookup('template', 'override.yaml.j2'))
+      }}
+
+- name: KVMD Override Config - Replace override file
+  when: kvmd_override_contents_change_required
+  block:
+    - name: KVMD Override Config - Mount filesystem Read Write (rw)
+      ansible.builtin.import_tasks: shared/filesystem-mode.yml
+      vars:
+        fs_mode: rw
+
+    - name: KVMD Override Config - Apply the kvmd override template
+      ansible.builtin.template:
+        src: override.yaml.j2
+        dest: /etc/kvmd/override.yaml
+        mode: "0644"
+      notify:
+        - Reboot PiKVM

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -45,6 +45,12 @@
   vars:
     pikvm_version_mapped: "{{ pikvm_version_mapped | default('unknown') }}"
 
+- name: Configure KVMD Override
+  ansible.builtin.import_tasks: kvmd-override-config.yml
+  vars:
+    pikvm_version_mapped: "{{ pikvm_version_mapped | default('unknown') }}"
+  when: (kvmd_override.enabled | bool)
+
 - name: Force mount filesystem Read Write (ro)
   ansible.builtin.import_tasks: shared/filesystem-mode.yml
   vars:

--- a/templates/override.yaml.j2
+++ b/templates/override.yaml.j2
@@ -1,0 +1,16 @@
+kvmd:
+{% if not hdmi.passthrough.enabled and pikvm_version_mapped == "v4plus" %}
+    # HDMI Passthrough - Disable HDMI Passthrough on PiKVM v4plus
+    streamer:
+        forever: false
+        cmd_remove:
+            - "--v4p"
+{% endif %}
+{% if hid.mouse.jiggler.enabled %}
+    hid:
+        jiggler:
+            enabled: true
+{% if hid.mouse.jiggler.on_after_reboot %}
+            active: true
+{% endif %}
+{% endif %}


### PR DESCRIPTION
Enabled /etc/kvmd/override.yaml to be overwritten by the templated override.yaml file. This is disabled by default and must be modified by setting kvmd_override.enabled to true. Currently the override.yaml only contains settings for mouse jiggler options and hdmi passthrough options. This will be enhanced in the future but can currently break more complex override files due to not backing up. README was updated to reflect these changes.
