### PR TITLE
feature/ansible-lint-fix

### DIFF
--- a/tasks/edid-config.yml
+++ b/tasks/edid-config.yml
@@ -13,7 +13,7 @@
   block:
     - name: EDID Config - Read the default EDID file
       ansible.builtin.slurp:
-        src: "/usr/share/kvmd/configs.default/kvmd/edid/{{ pikvm_version_mapped }}.hex"
+        src: "/usr/share/kvmd/configs.default/kvmd/edid/{{ pikvm_version }}.hex"
       register: default_edid
 
     - name: EDID Config - Set current EDID value to default

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -43,12 +43,12 @@
 - name: Configure EDID file
   ansible.builtin.import_tasks: edid-config.yml
   vars:
-    pikvm_version_mapped: "{{ pikvm_version_mapped | default('unknown') }}"
+    pikvm_version: "{{ pikvm_version_mapped | default('unknown') }}"
 
 - name: Configure KVMD Override
   ansible.builtin.import_tasks: kvmd-override-config.yml
   vars:
-    pikvm_version_mapped: "{{ pikvm_version_mapped | default('unknown') }}"
+    pikvm_version: "{{ pikvm_version_mapped | default('unknown') }}"
   when: (kvmd_override.enabled | bool)
 
 - name: Force mount filesystem Read Write (ro)

--- a/templates/override.yaml.j2
+++ b/templates/override.yaml.j2
@@ -1,5 +1,5 @@
 kvmd:
-{% if not hdmi.passthrough.enabled and pikvm_version_mapped == "v4plus" %}
+{% if not hdmi.passthrough.enabled and pikvm_version == "v4plus" %}
     # HDMI Passthrough - Disable HDMI Passthrough on PiKVM v4plus
     streamer:
         forever: false


### PR DESCRIPTION
Modified the main.yml vars for importing tasks to use pikvm_version instead of re-declaring pikvm_version_mapped for the variable name. This fixes ansible-linting errors.
