### PR TITLE
feature/variable-convention-update

### DIFF
--- a/.github/workflows/link-checker.yaml
+++ b/.github/workflows/link-checker.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Update Issue
         uses: peter-evans/create-issue-from-file@v5
         with:
-          title: Broken links detected in docs
+          title: Link Checker
           issue-number: "${{ steps.link-checker-issue.outputs.issue-number }}"
           content-filepath: ./lychee/out.md
           token: "${{ steps.generate-token.outputs.token }}"

--- a/README.md
+++ b/README.md
@@ -27,79 +27,67 @@ The following PiKVM version(s) are currently unsupported and may not work with t
 
 ## Role Variables
 
-`oled.enabled` By setting this value to **true**, it enables the physical OLED screen on the PiKVM device. By default this is set to **false** since not all PiKVM devices utilize an OLED screen.
+`oled_enabled` By setting this value to **true**, it enables the physical OLED screen on the PiKVM device. By default this is set to **false** since not all PiKVM devices utilize an OLED screen.
 
-`oled.rotate` By setting this value to **true**, the PiKVM OLED screen will be rotated. This is useful if the screen is the incorrect orientation from which you want displayed. For this setting to be applied, `oled.enabled` must be set to **true**. By default this value is set to **false**.
+`oled_rotate` By setting this value to **true**, the PiKVM OLED screen will be rotated. This is useful if the screen is the incorrect orientation from which you want displayed. For this setting to be applied, `oled_enabled` must be set to **true**. By default this value is set to **false**.
 
-`oled.fahrenheit` By setting this value to **true**, the PiKVM OLED screen will display temperature in Fahrenheit units instead of Celcius. For this setting to be applied, `oled.enabled` must be set to **true**. By default this value is set to **false**.
+`oled_fahrenheit` By setting this value to **true**, the PiKVM OLED screen will display temperature in Fahrenheit units instead of Celcius. For this setting to be applied, `oled_enabled` must be set to **true**. By default this value is set to **false**.
 
-`fan.enabled` By setting this value to **true**, the PiKVM will activate the FAN header pins allowing power to a physical fan. By default this is set to **true** since the PiKVM is recommended to have active cooling.
+`fan_enabled` By setting this value to **true**, the PiKVM will activate the FAN header pins allowing power to a physical fan. By default this is set to **true** since the PiKVM is recommended to have active cooling.
 
-`web_terminal.enabled` By setting this value to **true**, the PiKVM WebUI will enable terminal access. If set to false, no terminal actions can be performed from within the WebUI and must be performed by the root user using SSH. By default this is set to **true** to allow WebUI admin terminal access. ***Warning - All WebUI users have the same access rights. This means that any additional users besides the default admin account created for the WebUI will also have full access to the terminal.***
+`web_terminal_enabled` By setting this value to **true**, the PiKVM WebUI will enable terminal access. If set to false, no terminal actions can be performed from within the WebUI and must be performed by the root user using SSH. By default this is set to **true** to allow WebUI admin terminal access. ***Warning - All WebUI users have the same access rights. This means that any additional users besides the default admin account created for the WebUI will also have full access to the terminal.***
 
 `pikvm_os_update_output_logs` By setting this value to **true**, during execution of this role, the system update output will be displayed within the ansible logs. This can be useful to see what packages are updated during role execution. By default this is set to **true**.
 
-`hdmi.edid.custom` If set, a custom HDMI EDID value will override the PiKVM default. By default, the EDID value will be set based on the PiKVM OS version.
+`hdmi_edid` If set, a custom HDMI EDID value will override the PiKVM default. By default, the EDID value will be set based on the PiKVM OS version.
 
-`hdmi.passthrough.enabled` This option is only available for PiKVM V4 Plus. By setting this value to **false**, the OUT2 port on the back side of the PiKVM V4 Plus will be disabled. By default this option is set to **true**. To enable this setting, `kvmd_override.enabled` must also be set to **true**.
+`hdmi_passthrough_enabled` This option is only available for PiKVM V4 Plus. By setting this value to **false**, the OUT2 port on the back side of the PiKVM V4 Plus will be disabled. By default this option is set to **true**. To enable this setting, `kvmd_override_enabled` must also be set to **true**.
 
-`validate.validators.system` By setting this value to **true**, this role will validate the PiKVM required files and system packages before configuring anything. When using an official PiKVM OS provided by PiKVM, this should pass without issue, however, by setting this value to **true**, it ensures that any custom OS is able to be properly configured. By default this is set to **true**.
+`validate_system` By setting this value to **true**, this role will validate the PiKVM required files and system packages before configuring anything. When using an official PiKVM OS provided by PiKVM, this should pass without issue, however, by setting this value to **true**, it ensures that any custom OS is able to be properly configured. By default this is set to **true**.
 
-`validate.validators.prometheus` By default PiKVM allows Prometheus scraping by exposing metrics on the `/api/export/prometheus/metrics` endpoint. By setting this value to **true**, this role will validate that the metrics endpoint is available and correctly configured. By default this is set to **true**.
+`validate_prometheus` By default PiKVM allows Prometheus scraping by exposing metrics on the `/api/export/prometheus/metrics` endpoint. By setting this value to **true**, this role will validate that the metrics endpoint is available and correctly configured. By default this is set to **true**.
 
-`validate.fail_on_validate` By setting this value to **true**, any validators that fail will stop the role from continuing execution. This is helpful to prevent unknown issues from occuring during role execution if a validator fails. By default this is set to **true**.
+`validatefail_on_error` By setting this value to **true**, any validators that fail will stop the role from continuing execution. This is helpful to prevent unknown issues from occuring during role execution if a validator fails. By default this is set to **true**.
 
-`hid.mouse.jiggler.enabled` By setting this value to **true**, the virtual mouse jiggler will be available for use within the WebUI. By default this value is set to **false**. This setting does not turn ON the mouse jiggler, instead, it allows the user to activate it manually. To enable this setting, `kvmd_override.enabled` must also be set to **true**.
+`mouse_jiggler_enabled` By setting this value to **true**, the virtual mouse jiggler will be available for use within the WebUI. By default this value is set to **false**. This setting does not turn ON the mouse jiggler, instead, it allows the user to activate it manually. To enable this setting, `kvmd_override_enabled` must also be set to **true**.
 
-`hid.mouse.jiggler.on_after_reboot` By setting this value to **true**, the virtual mouse jiggler will become active after reboot. By default this value is set to **false**. This setting turns ON the mouse jiggler by default after reboot. If you wish to have manual control over the activation of this setting after reboot, do not set this value to true. `hid.mouse.jiggler.enabled` must be set to **true** for this setting to be applied. To enable this setting, `kvmd_override.enabled` must also be set to **true**.
+`mouse_jiggler_on_after_reboot` By setting this value to **true**, the virtual mouse jiggler will become active after reboot. By default this value is set to **false**. This setting turns ON the mouse jiggler by default after reboot. If you wish to have manual control over the activation of this setting after reboot, do not set this value to true. `mouse_jiggler_enabled` must be set to **true** for this setting to be applied. To enable this setting, `kvmd_override_enabled` must also be set to **true**.
 
-`kvmd_override.enabled` By setting this value to **true**, the current override file within /etc/kvmd/override.yaml will be overwritten to match this roles config. By default this value is set to **false**.
+`kvmd_override_enabled` By setting this value to **true**, the current override file within /etc/kvmd/override.yaml will be overwritten to match this roles config. By default this value is set to **false**.
 
 ### Example Variable Usage
 
 ```yaml
-oled:
-  enabled: true
-  rotate: false
-  fahrenheit: false
-fan:
-  enabled: true
-web_terminal:
-  enabled: false
+oled_enabled: true
+oled_rotate: false
+oled_fahrenheit: false
+fan_enabled: true
+web_terminal_enabled: false
 pikvm_os_update_output_logs: true
-hdmi:
-  edid:
-    custom: |
-      00FFFFFFFFFFFF005262888800888888
-      1C150103800000780AEE91A3544C9926
-      0F505425400001000100010001000100
-      010001010101D32C80A070381A403020
-      350040442100001E7E1D00A050001940
-      3020370080001000001E000000FC0050
-      492D4B564D20566964656F0A000000FD
-      00323D0F2E0F000000000000000001C4
-      02030400DE0D20A03058122030203400
-      F0B400000018E01500A0400016303020
-      3400000000000018B41400A050D01120
-      3020350080D810000018AB22A0A05084
-      1A3030203600B00E1100001800000000
-      00000000000000000000000000000000
-      00000000000000000000000000000000
-      00000000000000000000000000000045
-  passthrough:
-    enabled: false
-validate:
-  validators:
-    system: true
-    prometheus: true
-  fail_on_validate: false
-hid:
-  mouse:
-    jiggler:
-      enabled: true
-      on_after_reboot: true
-kvmd_override:
-  enabled: true
+hdmi_edid: |
+  00FFFFFFFFFFFF005262888800888888
+  1C150103800000780AEE91A3544C9926
+  0F505425400001000100010001000100
+  010001010101D32C80A070381A403020
+  350040442100001E7E1D00A050001940
+  3020370080001000001E000000FC0050
+  492D4B564D20566964656F0A000000FD
+  00323D0F2E0F000000000000000001C4
+  02030400DE0D20A03058122030203400
+  F0B400000018E01500A0400016303020
+  3400000000000018B41400A050D01120
+  3020350080D810000018AB22A0A05084
+  1A3030203600B00E1100001800000000
+  00000000000000000000000000000000
+  00000000000000000000000000000000
+  00000000000000000000000000000045
+hdmi_passthrough_enabled: false
+validate_system: true
+validate_prometheus: true
+validate_fail_on_error: false
+mouse_jiggler_enabled: true
+mouse_jiggler_on_after_reboot: false
+kvmd_override_enabled: true
 ```
 
 ## Example Playbook
@@ -139,7 +127,7 @@ This role will update system packages if available to the most recent version. T
 
 This role will cause the PiKVM to reboot if required. This action cannot currently be disabled.
 
-If `kvmd_override.enabled` is set to **true**, the current /etc/kvmd/override.yaml file will be overwritten and cannot be recovered. Please ensure that you have a backup of the current override.yaml file.
+If `kvmd_override_enabled` is set to **true**, the current /etc/kvmd/override.yaml file will be overwritten and cannot be recovered. Please ensure that you have a backup of the current override.yaml file.
 
 **Warning**: By using this role, you acknowledge that it may impact any existing installations or configurations on your PiKVM device. This role and its contributors are not responsible for any data loss, configuration changes, or other issues that may arise. Use at your own risk and ensure you have appropriate backups and safeguards in place before running this role on a production device.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,27 +1,15 @@
 ---
-oled:
-  enabled: false
-  rotate: false
-  fahrenheit: false
-fan:
-  enabled: true
-web_terminal:
-  enabled: true
+oled_enabled: false
+oled_rotate: false
+oled_fahrenheit: false
+fan_enabled: true
+web_terminal_enabled: true
 pikvm_os_update_output_logs: true
-hdmi:
-  edid:
-    custom: null
-  passthrough:
-    enabled: false
-validate:
-  validators:
-    system: true
-    prometheus: true
-  fail_on_validate: false
-hid:
-  mouse:
-    jiggler:
-      enabled: false
-      on_after_reboot: false
-kvmd_override:
-  enabled: false
+hdmi_edid: null
+hdmi_passthrough_enabled: false
+validate_system: true
+validate_prometheus: true
+validate_fail_on_error: true
+mouse_jiggler_enabled: false
+mouse_jiggler_on_after_reboot: false
+kvmd_override_enabled: false

--- a/tasks/edid-config.yml
+++ b/tasks/edid-config.yml
@@ -9,7 +9,7 @@
     decoded_current_edid: "{{ current_edid.content | b64decode }}"
 
 - name: EDID Config - Set EDID to default value
-  when: (hdmi.edid.custom | default("") | length == 0)
+  when: (hdmi_edid | default("") | length == 0)
   block:
     - name: EDID Config - Read the default EDID file
       ansible.builtin.slurp:
@@ -32,19 +32,19 @@
             force: true
           notify: Reboot PiKVM
 
-- name: EDID Config - Set EDID to custom value
+- name: EDID Config - Set EDID
   when: >
-    (hdmi.edid.custom | default("") | length > 0)
-    and (hdmi.edid.custom != decoded_current_edid)
+    (hdmi_edid | default("") | length > 0)
+    and (hdmi_edid != decoded_current_edid)
   block:
     - name: EDID Config - Mount filesystem Read Write (rw)
       ansible.builtin.import_tasks: shared/filesystem-mode.yml
       vars:
         fs_mode: rw
 
-    - name: EDID Config - Override tc358743-edid hex file with custom EDID value if not the same
+    - name: EDID Config - Override tc358743-edid hex file with EDID value if not the same
       ansible.builtin.copy:
-        content: "{{ hdmi.edid.custom }}"
+        content: "{{ hdmi_edid }}"
         dest: /etc/kvmd/tc358743-edid.hex
         mode: "0640"
         force: true

--- a/tasks/fan-config.yml
+++ b/tasks/fan-config.yml
@@ -6,8 +6,8 @@
 
 - name: Fan Config - PiKVM fan configuration block
   when: >
-    (kvmd_fan_status.status.UnitFileState == 'disabled' and fan.enabled | bool) or
-    (kvmd_fan_status.status.UnitFileState == 'enabled' and not fan.enabled | bool)
+    (kvmd_fan_status.status.UnitFileState == 'disabled' and fan_enabled | bool) or
+    (kvmd_fan_status.status.UnitFileState == 'enabled' and not fan_enabled | bool)
   block:
     - name: Fan Config - Mount filesystem Read Write (rw)
       ansible.builtin.import_tasks: shared/filesystem-mode.yml
@@ -17,5 +17,5 @@
     - name: Fan Config - Manage kvmd-fan service
       ansible.builtin.systemd:
         name: kvmd-fan
-        enabled: "{{ fan.enabled }}"
+        enabled: "{{ fan_enabled }}"
       notify: Reboot PiKVM

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,11 +1,11 @@
 ---
 - name: Validate System
   ansible.builtin.import_tasks: validate/system-validate.yml
-  when: (validate.validators.system | bool)
+  when: (validate_system | bool)
 
 - name: Validate Prometheus
   ansible.builtin.import_tasks: validate/prometheus-validate.yml
-  when: (validate.validators.prometheus | bool)
+  when: (validate_prometheus | bool)
 
 - name: Check and extract PiKVM OS version
   ansible.builtin.shell:
@@ -49,7 +49,7 @@
   ansible.builtin.import_tasks: kvmd-override-config.yml
   vars:
     pikvm_version: "{{ pikvm_version_mapped | default('unknown') }}"
-  when: (kvmd_override.enabled | bool)
+  when: (kvmd_override_enabled | bool)
 
 - name: Force mount filesystem Read Write (ro)
   ansible.builtin.import_tasks: shared/filesystem-mode.yml

--- a/tasks/oled-config.yml
+++ b/tasks/oled-config.yml
@@ -17,12 +17,12 @@
 - name: OLED Config - Check filesystem change required for OLED services
   ansible.builtin.set_fact:
     oled_kvmd_change_required: "{{
-        (kvmd_oled_status.status.UnitFileState == 'disabled' and oled.enabled | bool) or
-        (kvmd_oled_status.status.UnitFileState == 'enabled' and not oled.enabled | bool) or
-        (kvmd_oled_reboot_status.status.UnitFileState == 'disabled' and oled.enabled | bool) or
-        (kvmd_oled_reboot_status.status.UnitFileState == 'enabled' and not oled.enabled | bool) or
-        (kvmd_oled_shutdown_status.status.UnitFileState == 'disabled' and oled.enabled | bool) or
-        (kvmd_oled_shutdown_status.status.UnitFileState == 'enabled' and not oled.enabled | bool)
+        (kvmd_oled_status.status.UnitFileState == 'disabled' and oled_enabled | bool) or
+        (kvmd_oled_status.status.UnitFileState == 'enabled' and not oled_enabled | bool) or
+        (kvmd_oled_reboot_status.status.UnitFileState == 'disabled' and oled_enabled | bool) or
+        (kvmd_oled_reboot_status.status.UnitFileState == 'enabled' and not oled_enabled | bool) or
+        (kvmd_oled_shutdown_status.status.UnitFileState == 'disabled' and oled_enabled | bool) or
+        (kvmd_oled_shutdown_status.status.UnitFileState == 'enabled' and not oled_enabled | bool)
       }}"
 
 - name: OLED Config - Check if kvmd-oled override file exists
@@ -45,8 +45,8 @@
       ExecStart=
       ExecStart=/usr/bin/kvmd-oled --clear-on-exit{{ rotate_option }}{{ fahrenheit_option }}
   vars:
-    rotate_option: "{{ ' --height=32 --rotate=2' if oled.rotate | bool else '' }}"
-    fahrenheit_option: "{{ ' --fahrenheit' if oled.fahrenheit | bool else '' }}"
+    rotate_option: "{{ ' --height=32 --rotate=2' if oled_rotate | bool else '' }}"
+    fahrenheit_option: "{{ ' --fahrenheit' if oled_fahrenheit | bool else '' }}"
 
 - name: OLED Config - Set all relevant OLED configuration facts
   ansible.builtin.set_fact:
@@ -57,8 +57,8 @@
   ansible.builtin.set_fact:
     oled_override_change_required: >-
       {{
-        oled.enabled and
-        ((oled.rotate | bool or oled.fahrenheit | bool) and
+        oled_enabled and
+        ((oled_rotate | bool or oled_fahrenheit | bool) and
         (current_oled_override_normalized != desired_oled_override_normalized))
       }}
 
@@ -66,8 +66,8 @@
   ansible.builtin.set_fact:
     oled_override_removal_required: >-
       {{
-        ((not oled.rotate | bool and not oled.fahrenheit | bool) or
-        (not oled.enabled | bool)) and
+        ((not oled_rotate | bool and not oled_fahrenheit | bool) or
+        (not oled_enabled | bool)) and
         (oled_override_file.stat.exists | default(false))
       }}
 
@@ -85,7 +85,7 @@
     - name: OLED Config - Manage OLED services
       ansible.builtin.systemd:
         name: "{{ item }}"
-        enabled: "{{ oled.enabled }}"
+        enabled: "{{ oled_enabled }}"
       loop:
         - kvmd-oled
         - kvmd-oled-reboot
@@ -112,9 +112,9 @@
               ExecStart=/usr/bin/kvmd-oled --clear-on-exit{{ rotate_option }}{{ fahrenheit_option }}
             mode: "0640"
           vars:
-            rotate_option: "{{ ' --height=32 --rotate=2' if oled.rotate | bool else '' }}"
-            fahrenheit_option: "{{ ' --fahrenheit' if oled.fahrenheit | bool else '' }}"
-          when: (oled.rotate | bool) or (oled.fahrenheit | bool)
+            rotate_option: "{{ ' --height=32 --rotate=2' if oled_rotate | bool else '' }}"
+            fahrenheit_option: "{{ ' --fahrenheit' if oled_fahrenheit | bool else '' }}"
+          when: (oled_rotate | bool) or (oled_fahrenheit | bool)
 
     - name: OLED Config - Remove kvmd-oled override file
       when: (oled_override_removal_required | bool)

--- a/tasks/validate/prometheus-validate.yml
+++ b/tasks/validate/prometheus-validate.yml
@@ -23,4 +23,4 @@
       }}
   failed_when: >
     (prometheus_check.status != 200)
-    and (validate.fail_on_validate)
+    and (validate_fail_on_error)

--- a/tasks/validate/system-validate.yml
+++ b/tasks/validate/system-validate.yml
@@ -13,4 +13,4 @@
       }}
   failed_when: >
     (not kvmd_binary.stat.exists)
-    and (validate.fail_on_validate)
+    and (validate_fail_on_error)

--- a/tasks/web-terminal-config.yml
+++ b/tasks/web-terminal-config.yml
@@ -6,8 +6,8 @@
 
 - name: Web Terminal Config - Configure terminal state
   when: >
-    (kvmd_web_terminal_status.status.UnitFileState == 'disabled' and web_terminal.enabled | bool) or
-    (kvmd_web_terminal_status.status.UnitFileState == 'enabled' and not web_terminal.enabled | bool)
+    (kvmd_web_terminal_status.status.UnitFileState == 'disabled' and web_terminal_enabled | bool) or
+    (kvmd_web_terminal_status.status.UnitFileState == 'enabled' and not web_terminal_enabled | bool)
   block:
     - name: Web Terminal Config - Mount filesystem Read Write (rw)
       ansible.builtin.import_tasks: shared/filesystem-mode.yml
@@ -17,5 +17,5 @@
     - name: Web Terminal Config - Manage web terminal
       ansible.builtin.systemd:
         name: kvmd-webterm
-        enabled: "{{ web_terminal.enabled }}"
+        enabled: "{{ web_terminal_enabled }}"
       notify: Reboot PiKVM

--- a/templates/override.yaml.j2
+++ b/templates/override.yaml.j2
@@ -1,16 +1,16 @@
 kvmd:
-{% if not hdmi.passthrough.enabled and pikvm_version == "v4plus" %}
+{% if not hdmi_passthrough_enabled and pikvm_version == "v4plus" %}
     # HDMI Passthrough - Disable HDMI Passthrough on PiKVM v4plus
     streamer:
         forever: false
         cmd_remove:
             - "--v4p"
 {% endif %}
-{% if hid.mouse.jiggler.enabled %}
+{% if mouse_jiggler_enabled %}
     hid:
         jiggler:
             enabled: true
-{% if hid.mouse.jiggler.on_after_reboot %}
+{% if mouse_jiggler_on_after_reboot %}
             active: true
 {% endif %}
 {% endif %}


### PR DESCRIPTION
This is a BREAKING change from previous versions. This change modifies variable defaults to individual variables instead of within nested blocks. This allows for overriding of defaults without needing to specify the entire block. Without this change, attempting to modify a single variable required the entire block to be defined within the role vars.
