### PR TITLE
feature/serial-over-usb-config

### DIFF
--- a/.github/linters/.markdownlint.yaml
+++ b/.github/linters/.markdownlint.yaml
@@ -15,8 +15,6 @@ MD013:
   tables: true
   # Include headings
   headings: true
-  # Include headings
-  headers: true
   # Strict length checking
   strict: false
   # Stern length checking

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ The following PiKVM version(s) are currently unsupported and may not work with t
 
 `kvmd_override_enabled` By setting this value to **true**, the current override file within /etc/kvmd/override.yaml will be overwritten to match this roles config. By default this value is set to **false**.
 
+`serial_over_usb_enabled` By setting this value to **true**, the PiKVM will be configured to allow serial connections over USB. This can be used for terminal access from the managed server to the PiKVM, or for any other purpose that requires a serial connection. This is only available for PiKVM V2+.
+
 ### Example Variable Usage
 
 ```yaml
@@ -79,6 +81,7 @@ hdmi_passthrough_enabled: false
 mouse_jiggler_enabled: true
 mouse_jiggler_on_after_reboot: false
 kvmd_override_enabled: true
+serial_over_usb_enabled: false
 ```
 
 ## Example Playbook

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,3 +10,4 @@ hdmi_passthrough_enabled: false
 mouse_jiggler_enabled: false
 mouse_jiggler_on_after_reboot: false
 kvmd_override_enabled: false
+serial_over_usb_enabled: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,6 +14,10 @@
 - name: Manage web terminal
   ansible.builtin.import_tasks: web-terminal-config.yml
 
+- name: Configure serial-over-usb
+  ansible.builtin.import_tasks: serial-over-usb-config.yml
+  when: (pikvm_version_mapped in v2_incremental_list)
+
 - name: Configure EDID file
   ansible.builtin.import_tasks: edid-config.yml
   vars:

--- a/tasks/serial-over-usb-config.yml
+++ b/tasks/serial-over-usb-config.yml
@@ -1,0 +1,74 @@
+---
+- name: Check current state of ttyGS0 in /etc/securetty
+  ansible.builtin.slurp:
+    src: /etc/securetty
+  register: securetty
+  changed_when: false
+
+- name: Debug securetty contents
+  ansible.builtin.set_fact:
+    decoded_current_securetty: "{{ securetty.content | b64decode }}"
+
+- name: Check if ttyGS0 exists in the securetty contents
+  ansible.builtin.set_fact:
+    ttyGS0_present: "{{ 'ttyGS0' in decoded_current_securetty }}"
+
+- name: Check whether serial-over-usb needs to be configured
+  ansible.builtin.set_fact:
+    serial_over_usb_change_required: "{{
+        ('ttyGS0' in decoded_current_securetty and not serial_over_usb_enabled) or
+        (not 'ttyGS0' in decoded_current_securetty and serial_over_usb_enabled)
+      }}"
+
+- name: Configure serial-over-usb when enabled
+  when: ( serial_over_usb_change_required | bool )
+  notify: Reboot PiKVM
+  block:
+    - name: Serial-Over-USB Config - Mount filesystem Read Write (rw)
+      ansible.builtin.import_tasks: shared/filesystem-mode.yml
+      vars:
+        fs_mode: rw
+
+    - name: Ensure ttyGS0 is listed in /etc/securetty
+      ansible.builtin.lineinfile:
+        path: /etc/securetty
+        line: ttyGS0
+        state: "{{ 'present' if serial_over_usb_enabled else 'absent' }}"
+        mode: "0644"
+
+    - name: Ensure directory and override.conf are present
+      when: ( serial_over_usb_enabled | bool )
+      block:
+        - name: Create directory for systemd override
+          ansible.builtin.file:
+            path: /etc/systemd/system/getty@ttyGS0.service.d
+            state: directory
+            mode: "0755"
+
+        - name: Create systemd override configuration
+          ansible.builtin.copy:
+            dest: /etc/systemd/system/getty@ttyGS0.service.d/override.conf
+            content: |
+              [Service]
+              TTYReset=no
+              TTYVHangup=no
+              TTYVTDisallocate=no
+            mode: "0644"
+
+        - name: Enable getty@ttyGS0.service
+          ansible.builtin.systemd:
+            name: getty@ttyGS0.service
+            enabled: true
+
+    - name: Ensure directory and override.conf are absent
+      when: not ( serial_over_usb_enabled | bool )
+      block:
+        - name: Remove getty@ttyGS0.service.d override directory
+          ansible.builtin.file:
+            path: /etc/systemd/system/getty@ttyGS0.service.d
+            state: absent
+
+        - name: Disable getty@ttyGS0.service
+          ansible.builtin.systemd:
+            name: getty@ttyGS0.service
+            enabled: false

--- a/tasks/validate/system-validate.yml
+++ b/tasks/validate/system-validate.yml
@@ -34,3 +34,15 @@
         validate_certs: false
       register: prometheus_check
       failed_when: (prometheus_check.status != 200)
+
+- name: System Validate - Ensure /etc/kvmd/tc358743-edid.hex exists
+  ansible.builtin.stat:
+    path: /etc/kvmd/tc358743-edid.hex
+  register: tc358743_edid
+  failed_when: (not tc358743_edid.stat.exists)
+
+- name: System Validate - Ensure /etc/securetty exists
+  ansible.builtin.stat:
+    path: /etc/securetty
+  register: securetty
+  failed_when: (not securetty.stat.exists)

--- a/templates/override.yaml.j2
+++ b/templates/override.yaml.j2
@@ -14,3 +14,9 @@ kvmd:
             active: true
 {% endif %}
 {% endif %}
+{% if serial_over_usb_enabled and pikvm_version in v2_incremental_list %}
+otg:
+    devices:
+        serial:
+            enabled: true
+{% endif %}

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,2 +1,7 @@
 ---
-# vars file ansible-role-pikvm
+pikvm_version_list: ['v0', 'v1', 'v2', 'v3', 'v4mini', 'v4plus']
+v0_incremental_list: ['v0', 'v1', 'v2', 'v3', 'v4mini', 'v4plus']
+v1_incremental_list: ['v1', 'v2', 'v3', 'v4mini', 'v4plus']
+v2_incremental_list: ['v2', 'v3', 'v4mini', 'v4plus']
+v3_incremental_list: ['v3', 'v4mini', 'v4plus']
+v4_incremental_list: ['v4mini', 'v4plus']


### PR DESCRIPTION
Modified kvmd override config to include a section for serial-over-usb configuration. This is only applicable to pikvm version 2+ so a list of version requirements were added to the vars. Additionally, modified the readme.md to reflect the changes. All serial-over-usb services are idempotent with these changes and should not affect existing deployments. Lastly, modified the validation to ensure the needed files for modification exist before starting.

